### PR TITLE
feat: updated PMD rule names for PMD v6.55.0

### DIFF
--- a/java/config/v0.0.2/pmd/pmd-main-6.55.0.xml
+++ b/java/config/v0.0.2/pmd/pmd-main-6.55.0.xml
@@ -1,0 +1,160 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<ruleset xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	name="AW Java ruleset"
+	xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 http://pmd.sourceforge.net/ruleset_2_0_0.xsd">
+  <description>
+     Custom ruleset for Java projects
+  </description>
+
+  <rule ref="category/java/bestpractices.xml">
+
+    <exclude name="JUnitTestContainsTooManyAsserts"/>
+    <exclude name="LooseCoupling" />
+    <exclude name="OneDeclarationPerLine" />
+	 
+    <exclude name="GuardLogStatement" />
+
+    <!-- Duplicate of Checkstyle's UnusedImports, which understands javadoc -->
+    <exclude name="UnusedImports"/>
+    <exclude name="UseVarargs"/>
+
+    <!-- The new PMD checks for concatenations, it's ok then! -->
+    <!-- <exclude name="GuardLogStatement"/> -->
+
+    <!-- Assume we have few meaningful asserts, making this desired but not required -->
+    <exclude name="JUnitAssertionsShouldIncludeMessage" />
+  </rule>
+
+  <rule ref="category/java/codestyle.xml">
+
+    <exclude name="CommentDefaultAccessModifier"/> 
+	  
+    <!-- Confusing ternary needs special configuration -->
+    <exclude name="ConfusingTernary"/>
+    
+    <!-- Checkstyle's FinalParametersCheck forces final vars instead of detecting those that could be final -->
+    <exclude name="MethodArgumentCouldBeFinal"/>
+    <exclude name="LocalVariableCouldBeFinal"/>
+
+    <!-- old controversial rules -->
+    <exclude name="AtLeastOneConstructor"/>
+    <exclude name="AvoidFinalLocalVariable"/>
+    <exclude name="AvoidPrefixingMethodParameters"/>
+    <exclude name="AvoidUsingNativeCode"/>
+    <exclude name="CallSuperInConstructor"/>
+    <exclude name="DefaultPackage"/>
+    <exclude name="OnlyOneReturn"/>
+
+    <!-- j2ee rules -->
+    <exclude name="LocalHomeNamingConvention" />
+    <exclude name="LocalInterfaceSessionNamingConvention" />
+    <exclude name="MDBAndSessionBeanNamingConvention" />
+    <exclude name="RemoteInterfaceNamingConvention" />
+    <exclude name="RemoteSessionInterfaceNamingConvention" />
+
+    <!-- Naming rules are disabled - TODO we need to revise them and configure them -->
+    <exclude name="AbstractNaming"/>
+    <exclude name="ClassNamingConventions"/>
+    <exclude name="LongVariable"/>
+    <exclude name="MethodNamingConventions"/>
+    <exclude name="MIsLeadingVariableName"/>
+    <exclude name="ShortClassName"/>
+    <exclude name="ShortMethodName"/>
+    <exclude name="ShortVariable"/>
+    <exclude name="SuspiciousConstantFieldName"/>
+    <exclude name="VariableNamingConventions"/>
+
+    <exclude name="TooManyStaticImports"/>
+
+    <!-- braces rules are covered by Checkstyle -->
+    <exclude name="ForLoopsMustUseBraces"/>
+    <exclude name="IfElseStmtsMustUseBraces"/>
+    <exclude name="IfStmtsMustUseBraces"/>
+    <exclude name="WhileLoopsMustUseBraces"/>
+  </rule>
+
+  <!-- ConfusingTernaryRule should ignore elseif since it creates lots of FPs -->
+  <rule ref="category/java/codestyle.xml/ConfusingTernary">
+    <properties>
+      <property name="ignoreElseIf" value="true"/>
+    </properties>
+  </rule>
+
+  <rule ref="category/java/design.xml">
+    <exclude name="CouplingBetweenObjects" />
+    <exclude name="ExcessiveImports" />
+    <exclude name="LawOfDemeter" />
+    <exclude name="LoosePackageCoupling" />
+
+    <!-- TODO : review these -->
+    <exclude name="CyclomaticComplexity" />
+    <exclude name="ExcessiveClassLength" />
+    <exclude name="ExcessiveMethodLength" />
+    <exclude name="ExcessiveParameterList" />
+    <exclude name="ExcessivePublicCount" />
+    <exclude name="ModifiedCyclomaticComplexity" />
+    <exclude name="NcssConstructorCount" />
+    <exclude name="NcssCount" />
+    <exclude name="NcssMethodCount" />
+    <exclude name="NcssTypeCount" />
+    <exclude name="NPathComplexity" />
+    <exclude name="StdCyclomaticComplexity" />
+    <exclude name="TooManyFields" />
+    <exclude name="TooManyMethods" />
+    <exclude name="UseObjectForClearerAPI" />
+    <exclude name="DataClass" />
+  </rule>
+
+  <rule ref="category/java/documentation.xml">
+    <exclude name="CommentContent"/>
+    <exclude name="CommentRequired"/>
+    <exclude name="CommentSize"/>
+  </rule>
+
+  <rule ref="category/java/errorprone.xml">
+    <exclude name="AvoidDuplicateLiterals"/>
+    <exclude name="CloneThrowsCloneNotSupportedException"/>
+
+    <!-- old controversial rules -->
+    <exclude name="AssignmentInOperand" />
+    <exclude name="AvoidAccessibilityAlteration" />
+    <exclude name="AvoidLiteralsInIfCondition" />
+    <exclude name="DataflowAnomalyAnalysis" />
+    <exclude name="DoNotCallGarbageCollectionExplicitly" />
+    <exclude name="NullAssignment" />
+    <exclude name="SuspiciousOctalEscape" />
+
+    <!-- beans rules -->
+    <exclude name="NonSerializableClass" />
+
+    <!-- j2ee rules -->
+    <exclude name="UseProperClassLoader" />
+    <exclude name="DoNotTerminateVM" />
+    <exclude name="StaticEJBFieldShouldBeFinal" />
+
+    <!-- Customized below. -->
+    <exclude name="EmptyCatchBlock"/>
+
+    <!-- We prefer checkstyle's FallThrough -->
+    <exclude name="ImplicitSwitchFallThrough"/>
+  </rule>
+
+  <rule ref="category/java/errorprone.xml/EmptyCatchBlock">
+    <properties>
+      <property name="allowCommentedBlocks" value="true"/>
+    </properties>
+  </rule>
+
+  <rule ref="category/java/multithreading.xml">
+    <exclude name="AvoidUsingVolatile"/>
+    <exclude name="UseConcurrentHashMap"/>
+
+    <!-- J2EE rules -->
+    <exclude name="DoNotUseThreads"/>
+  </rule>
+
+  <rule ref="category/java/performance.xml">
+    <exclude name="AvoidInstantiatingObjectsInLoops"/>
+  </rule>
+</ruleset>

--- a/java/config/v0.0.2/pmd/pmd-test-6.55.0.xml
+++ b/java/config/v0.0.2/pmd/pmd-test-6.55.0.xml
@@ -1,0 +1,160 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<ruleset xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	name="AW Java ruleset"
+	xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 http://pmd.sourceforge.net/ruleset_2_0_0.xsd">
+  <description>
+     Custom ruleset for Java projects
+  </description>
+
+  <rule ref="category/java/bestpractices.xml">
+
+    <exclude name="JUnitTestContainsTooManyAsserts"/>
+    <exclude name="LooseCoupling" />
+    <exclude name="OneDeclarationPerLine" />
+
+    <exclude name="GuardLogStatement" />
+
+    <!-- Duplicate of Checkstyle's UnusedImports, which understands javadoc -->
+    <exclude name="UnusedImports"/>
+    <exclude name="UseVarargs"/>
+
+    <!-- The new PMD checks for concatenations, it's ok then! -->
+    <!-- <exclude name="GuardLogStatement"/> -->
+
+    <!-- Assume we have few meaningful asserts, making this desired but not required -->
+    <exclude name="JUnitAssertionsShouldIncludeMessage" />
+  </rule>
+
+  <rule ref="category/java/codestyle.xml">
+	 
+    <exclude name="CommentDefaultAccessModifier"/> 
+
+    <!-- Confusing ternary needs special configuration -->
+    <exclude name="ConfusingTernary"/>
+    
+    <!-- Checkstyle's FinalParametersCheck forces final vars instead of detecting those that could be final -->
+    <exclude name="MethodArgumentCouldBeFinal"/>
+    <exclude name="LocalVariableCouldBeFinal"/>
+
+    <!-- old controversial rules -->
+    <exclude name="AtLeastOneConstructor"/>
+    <exclude name="AvoidFinalLocalVariable"/>
+    <exclude name="AvoidPrefixingMethodParameters"/>
+    <exclude name="AvoidUsingNativeCode"/>
+    <exclude name="CallSuperInConstructor"/>
+    <exclude name="DefaultPackage"/>
+    <exclude name="OnlyOneReturn"/>
+
+    <!-- j2ee rules -->
+    <exclude name="LocalHomeNamingConvention" />
+    <exclude name="LocalInterfaceSessionNamingConvention" />
+    <exclude name="MDBAndSessionBeanNamingConvention" />
+    <exclude name="RemoteInterfaceNamingConvention" />
+    <exclude name="RemoteSessionInterfaceNamingConvention" />
+
+    <!-- Naming rules are disabled - TODO we need to revise them and configure them -->
+    <exclude name="AbstractNaming"/>
+    <exclude name="ClassNamingConventions"/>
+    <exclude name="LongVariable"/>
+    <exclude name="MethodNamingConventions"/>
+    <exclude name="MIsLeadingVariableName"/>
+    <exclude name="ShortClassName"/>
+    <exclude name="ShortMethodName"/>
+    <exclude name="ShortVariable"/>
+    <exclude name="SuspiciousConstantFieldName"/>
+    <exclude name="VariableNamingConventions"/>
+
+    <exclude name="TooManyStaticImports"/>
+
+    <!-- braces rules are covered by Checkstyle -->
+    <exclude name="ForLoopsMustUseBraces"/>
+    <exclude name="IfElseStmtsMustUseBraces"/>
+    <exclude name="IfStmtsMustUseBraces"/>
+    <exclude name="WhileLoopsMustUseBraces"/>
+  </rule>
+
+  <!-- ConfusingTernaryRule should ignore elseif since it creates lots of FPs -->
+  <rule ref="category/java/codestyle.xml/ConfusingTernary">
+    <properties>
+      <property name="ignoreElseIf" value="true"/>
+    </properties>
+  </rule>
+
+  <rule ref="category/java/design.xml">
+    <exclude name="CouplingBetweenObjects" />
+    <exclude name="ExcessiveImports" />
+    <exclude name="LawOfDemeter" />
+    <exclude name="LoosePackageCoupling" />
+
+    <!-- TODO : review these -->
+    <exclude name="CyclomaticComplexity" />
+    <exclude name="ExcessiveClassLength" />
+    <exclude name="ExcessiveMethodLength" />
+    <exclude name="ExcessiveParameterList" />
+    <exclude name="ExcessivePublicCount" />
+    <exclude name="ModifiedCyclomaticComplexity" />
+    <exclude name="NcssConstructorCount" />
+    <exclude name="NcssCount" />
+    <exclude name="NcssMethodCount" />
+    <exclude name="NcssTypeCount" />
+    <exclude name="NPathComplexity" />
+    <exclude name="StdCyclomaticComplexity" />
+    <exclude name="TooManyFields" />
+    <exclude name="TooManyMethods" />
+    <exclude name="UseObjectForClearerAPI" />
+    <exclude name="DataClass" />
+  </rule>
+
+  <rule ref="category/java/documentation.xml">
+    <exclude name="CommentContent"/>
+    <exclude name="CommentRequired"/>
+    <exclude name="CommentSize"/>
+  </rule>
+
+  <rule ref="category/java/errorprone.xml">
+    <exclude name="AvoidDuplicateLiterals"/>
+    <exclude name="CloneThrowsCloneNotSupportedException"/>
+
+    <!-- old controversial rules -->
+    <exclude name="AssignmentInOperand" />
+    <exclude name="AvoidAccessibilityAlteration" />
+    <exclude name="AvoidLiteralsInIfCondition" />
+    <exclude name="DataflowAnomalyAnalysis" />
+    <exclude name="DoNotCallGarbageCollectionExplicitly" />
+    <exclude name="NullAssignment" />
+    <exclude name="SuspiciousOctalEscape" />
+
+    <!-- beans rules -->
+    <exclude name="NonSerializableClass" />
+
+    <!-- j2ee rules -->
+    <exclude name="UseProperClassLoader" />
+    <exclude name="DoNotTerminateVM" />
+    <exclude name="StaticEJBFieldShouldBeFinal" />
+
+    <!-- Customized below. -->
+    <exclude name="EmptyCatchBlock"/>
+
+    <!-- We prefer checkstyle's FallThrough -->
+    <exclude name="ImplicitSwitchFallThrough"/>
+  </rule>
+
+  <rule ref="category/java/errorprone.xml/EmptyCatchBlock">
+    <properties>
+      <property name="allowCommentedBlocks" value="true"/>
+    </properties>
+  </rule>
+
+  <rule ref="category/java/multithreading.xml">
+    <exclude name="AvoidUsingVolatile"/>
+    <exclude name="UseConcurrentHashMap"/>
+
+    <!-- J2EE rules -->
+    <exclude name="DoNotUseThreads"/>
+  </rule>
+
+  <rule ref="category/java/performance.xml">
+    <exclude name="AvoidInstantiatingObjectsInLoops"/>
+  </rule>
+</ruleset>


### PR DESCRIPTION
Certain rule names have been replaced or updated in PMD over the course of many updates from 6.26.0 to 6.55.0. This PR provides an updated exclude-rules XML document used for PMD static code analysis based on these changes.